### PR TITLE
feat: comply with Infura API changes

### DIFF
--- a/apps/itest/lib/plasma_framework.ex
+++ b/apps/itest/lib/plasma_framework.ex
@@ -54,7 +54,7 @@ defmodule Itest.PlasmaFramework do
   def exit_game_contract_address(tx_type) do
     data = ABI.encode("exitGames(uint256)", [tx_type])
 
-    {:ok, result} = Ethereumex.HttpClient.eth_call(%{to: address(), data: Encoding.to_hex(data)})
+    {:ok, result} = Ethereumex.HttpClient.eth_call(%{from: address(), to: address(), data: Encoding.to_hex(data)})
 
     result
     |> Encoding.to_binary()
@@ -66,7 +66,7 @@ defmodule Itest.PlasmaFramework do
   defp get_vault(id) do
     data = ABI.encode("vaults(uint256)", [id])
 
-    {:ok, result} = Ethereumex.HttpClient.eth_call(%{to: address(), data: Encoding.to_hex(data)})
+    {:ok, result} = Ethereumex.HttpClient.eth_call(%{from: address(), to: address(), data: Encoding.to_hex(data)})
 
     result
     |> Encoding.to_binary()

--- a/apps/itest/lib/poller.ex
+++ b/apps/itest/lib/poller.ex
@@ -230,7 +230,11 @@ defmodule Itest.Poller do
   defp do_root_chain_get_erc20_balance(address, currency) do
     data = ABI.encode("balanceOf(address)", [Encoding.to_binary(address)])
 
-    case Ethereumex.HttpClient.eth_call(%{to: Encoding.to_hex(currency), data: Encoding.to_hex(data)}) do
+    case Ethereumex.HttpClient.eth_call(%{
+           from: Encoding.to_hex(currency),
+           to: Encoding.to_hex(currency),
+           data: Encoding.to_hex(data)
+         }) do
       {:ok, result} ->
         balance =
           result

--- a/apps/itest/lib/standard_exit_client.ex
+++ b/apps/itest/lib/standard_exit_client.ex
@@ -159,7 +159,13 @@ defmodule Itest.StandardExitClient do
   defp get_bond_size_for_standard_exit(se) do
     _ = Logger.info("Trying to get bond size for standard exit.")
     data = ABI.encode("startStandardExitBondSize()", [])
-    {:ok, result} = Ethereumex.HttpClient.eth_call(%{to: se.exit_game_contract_address, data: Encoding.to_hex(data)})
+
+    {:ok, result} =
+      Ethereumex.HttpClient.eth_call(%{
+        from: se.exit_game_contract_address,
+        to: se.exit_game_contract_address,
+        data: Encoding.to_hex(data)
+      })
 
     standard_exit_bond_size =
       result
@@ -194,7 +200,13 @@ defmodule Itest.StandardExitClient do
   defp wait_for_exit_period(se) do
     _ = Logger.info("Wait for exit period to pass.")
     data = ABI.encode("minExitPeriod()", [])
-    {:ok, result} = Ethereumex.HttpClient.eth_call(%{to: Itest.PlasmaFramework.address(), data: Encoding.to_hex(data)})
+
+    {:ok, result} =
+      Ethereumex.HttpClient.eth_call(%{
+        from: Itest.PlasmaFramework.address(),
+        to: Itest.PlasmaFramework.address(),
+        data: Encoding.to_hex(data)
+      })
 
     not_from_deposit_multiplier = if se.exit_data && from_deposit?(se.exit_data.utxo_pos), do: 1, else: 2
 
@@ -222,7 +234,12 @@ defmodule Itest.StandardExitClient do
         se.exit_data.utxo_pos
       ])
 
-    {:ok, result} = Ethereumex.HttpClient.eth_call(%{to: se.exit_game_contract_address, data: Encoding.to_hex(data)})
+    {:ok, result} =
+      Ethereumex.HttpClient.eth_call(%{
+        from: se.exit_game_contract_address,
+        to: se.exit_game_contract_address,
+        data: Encoding.to_hex(data)
+      })
 
     standard_exit_id =
       result
@@ -232,7 +249,12 @@ defmodule Itest.StandardExitClient do
 
     data = ABI.encode("getNextExit(uint256,address)", [Itest.PlasmaFramework.vault_id(se.currency), se.currency])
 
-    {:ok, result} = Ethereumex.HttpClient.eth_call(%{to: Itest.PlasmaFramework.address(), data: Encoding.to_hex(data)})
+    {:ok, result} =
+      Ethereumex.HttpClient.eth_call(%{
+        from: Itest.PlasmaFramework.address(),
+        to: Itest.PlasmaFramework.address(),
+        data: Encoding.to_hex(data)
+      })
 
     next_exit_id =
       result
@@ -303,7 +325,11 @@ defmodule Itest.StandardExitClient do
       )
 
     {:ok, receipt_enc} =
-      Ethereumex.HttpClient.eth_call(%{to: Itest.PlasmaFramework.address(), data: Encoding.to_hex(data)})
+      Ethereumex.HttpClient.eth_call(%{
+        from: Itest.PlasmaFramework.address(),
+        to: Itest.PlasmaFramework.address(),
+        data: Encoding.to_hex(data)
+      })
 
     receipt_enc
     |> Encoding.to_binary()

--- a/apps/itest/test/itest/configuration_api_test.exs
+++ b/apps/itest/test/itest/configuration_api_test.exs
@@ -22,7 +22,11 @@ defmodule ConfigurationRetrievalTests do
     data = ABI.encode("getVersion()", [])
 
     {:ok, response} =
-      Ethereumex.HttpClient.eth_call(%{to: Itest.PlasmaFramework.address(), data: Encoding.to_hex(data)})
+      Ethereumex.HttpClient.eth_call(%{
+        from: Itest.PlasmaFramework.address(),
+        to: Itest.PlasmaFramework.address(),
+        data: Encoding.to_hex(data)
+      })
 
     [{contract_semver}] =
       response

--- a/apps/itest/test/itest/in_flight_exits_test.exs
+++ b/apps/itest/test/itest/in_flight_exits_test.exs
@@ -1034,7 +1034,12 @@ defmodule InFlightExitsTests do
     data =
       ABI.encode("getNextExit(uint256,address)", [Itest.PlasmaFramework.vault_id(Currency.ether()), Currency.ether()])
 
-    {:ok, result} = Ethereumex.HttpClient.eth_call(%{to: Itest.PlasmaFramework.address(), data: Encoding.to_hex(data)})
+    {:ok, result} =
+      Ethereumex.HttpClient.eth_call(%{
+        from: Itest.PlasmaFramework.address(),
+        to: Itest.PlasmaFramework.address(),
+        data: Encoding.to_hex(data)
+      })
 
     case Encoding.to_binary(result) do
       "" ->
@@ -1049,7 +1054,14 @@ defmodule InFlightExitsTests do
   defp wait_for_min_exit_period() do
     _ = Logger.info("Wait for exit period to pass.")
     data = ABI.encode("minExitPeriod()", [])
-    {:ok, result} = Ethereumex.HttpClient.eth_call(%{to: Itest.PlasmaFramework.address(), data: Encoding.to_hex(data)})
+
+    {:ok, result} =
+      Ethereumex.HttpClient.eth_call(%{
+        from: Itest.PlasmaFramework.address(),
+        to: Itest.PlasmaFramework.address(),
+        data: Encoding.to_hex(data)
+      })
+
     # result is in seconds
     result
     |> Encoding.to_binary()
@@ -1203,7 +1215,13 @@ defmodule InFlightExitsTests do
     _ = Logger.info("Get in flight exit id...")
     txbytes = Encoding.to_binary(exit_data.in_flight_tx)
     data = ABI.encode("getInFlightExitId(bytes)", [txbytes])
-    {:ok, result} = Ethereumex.HttpClient.eth_call(%{to: exit_game_contract_address, data: Encoding.to_hex(data)})
+
+    {:ok, result} =
+      Ethereumex.HttpClient.eth_call(%{
+        from: exit_game_contract_address,
+        to: exit_game_contract_address,
+        data: Encoding.to_hex(data)
+      })
 
     ife_exit_id =
       result
@@ -1219,7 +1237,13 @@ defmodule InFlightExitsTests do
   defp get_in_flight_exits(exit_game_contract_address, ife_exit_id) do
     _ = Logger.info("Get in flight exits...")
     data = ABI.encode("inFlightExits(uint160[])", [[ife_exit_id]])
-    {:ok, result} = Ethereumex.HttpClient.eth_call(%{to: exit_game_contract_address, data: Encoding.to_hex(data)})
+
+    {:ok, result} =
+      Ethereumex.HttpClient.eth_call(%{
+        from: exit_game_contract_address,
+        to: exit_game_contract_address,
+        data: Encoding.to_hex(data)
+      })
 
     return_struct = [
       {:array,
@@ -1296,7 +1320,13 @@ defmodule InFlightExitsTests do
   defp get_in_flight_exit_bond_size(exit_game_contract_address) do
     _ = Logger.info("Trying to get bond size for in flight exit.")
     data = ABI.encode("startIFEBondSize()", [])
-    {:ok, result} = Ethereumex.HttpClient.eth_call(%{to: exit_game_contract_address, data: Encoding.to_hex(data)})
+
+    {:ok, result} =
+      Ethereumex.HttpClient.eth_call(%{
+        from: exit_game_contract_address,
+        to: exit_game_contract_address,
+        data: Encoding.to_hex(data)
+      })
 
     result
     |> Encoding.to_binary()
@@ -1357,7 +1387,13 @@ defmodule InFlightExitsTests do
   defp get_piggyback_bond_size(exit_game_contract_address) do
     _ = Logger.info("Trying to get bond size for piggback.")
     data = ABI.encode("piggybackBondSize()", [])
-    {:ok, result} = Ethereumex.HttpClient.eth_call(%{to: exit_game_contract_address, data: Encoding.to_hex(data)})
+
+    {:ok, result} =
+      Ethereumex.HttpClient.eth_call(%{
+        from: exit_game_contract_address,
+        to: exit_game_contract_address,
+        data: Encoding.to_hex(data)
+      })
 
     piggyback_bond_size =
       result

--- a/apps/itest/test/test_helper.exs
+++ b/apps/itest/test/test_helper.exs
@@ -20,7 +20,13 @@ import Itest.Poller, only: [wait_on_receipt_confirmed: 1]
 
 Application.ensure_all_started(:ethereumex)
 data = ABI.encode("minExitPeriod()", [])
-{:ok, result} = Ethereumex.HttpClient.eth_call(%{to: Itest.PlasmaFramework.address(), data: Encoding.to_hex(data)})
+
+{:ok, result} =
+  Ethereumex.HttpClient.eth_call(%{
+    from: Itest.PlasmaFramework.address(),
+    to: Itest.PlasmaFramework.address(),
+    data: Encoding.to_hex(data)
+  })
 
 milliseconds =
   result


### PR DESCRIPTION
References omgnetwork/elixir-omg#1752
Changes:
- sets from argument in eth_call requests

Does not address Infura API changes in error response format because:

- it is handled well in ethereumex
- eth_call error response format changes only on Kovan.

When playing with current Infura API I could provide any address as `from` argument to `eth_call`.
We could probably do well with hardcoding any address as `from`.