### PR TITLE
use single nginx container

### DIFF
--- a/docker-compose-2-reorg.yml
+++ b/docker-compose-2-reorg.yml
@@ -64,4 +64,4 @@ services:
       geth-2:
         condition: service_healthy
     volumes:
-      - ./priv/cabbage/nginx.conf:/etc/nginx/server_config/geth.conf:ro
+      - ./priv/cabbage/nginx.conf:/etc/nginx/nginx.conf

--- a/docker-compose-2-reorg.yml
+++ b/docker-compose-2-reorg.yml
@@ -64,6 +64,4 @@ services:
       geth-2:
         condition: service_healthy
     volumes:
-      - ./priv/cabbage/nginx.conf:/etc/nginx/nginx.conf
-
-
+      - ./priv/cabbage/nginx.conf:/etc/nginx/server_config/geth.conf:ro

--- a/docker-compose-reorg.yml
+++ b/docker-compose-reorg.yml
@@ -58,9 +58,9 @@ services:
       chain_net:
         ipv4_address: 172.27.0.202
 
-  nginx_geth:
+  nginx:
     depends_on:
       - geth-1
       - geth-2
     volumes:
-      - ./priv/cabbage/nginx.conf:/etc/nginx/nginx.conf
+      - ./priv/cabbage/nginx.conf:/etc/nginx/server_config/geth.conf:ro

--- a/docker-compose-reorg.yml
+++ b/docker-compose-reorg.yml
@@ -63,4 +63,4 @@ services:
       - geth-1
       - geth-2
     volumes:
-      - ./priv/cabbage/nginx.conf:/etc/nginx/server_config/geth.conf:ro
+      - ./priv/cabbage/geth_nginx.conf:/etc/nginx/server_config/geth.conf:ro

--- a/geth_nginx.conf
+++ b/geth_nginx.conf
@@ -1,0 +1,36 @@
+upstream geth {
+    server 172.27.0.201:8545;
+    server 172.27.0.202:8545;
+}
+
+upstream websocket {
+    server 172.27.0.201:8546;
+    server 172.27.0.202:8546;
+}
+
+server {
+    listen 80;
+
+    location / {
+        proxy_pass http://geth;
+        proxy_next_upstream non_idempotent invalid_header error timeout http_500 http_502 http_504 http_403 http_404;
+        proxy_next_upstream_tries 4;
+        fastcgi_read_timeout 10;
+        proxy_read_timeout 10;
+    }
+}
+
+server {
+    listen 81;
+
+    location / {
+        proxy_pass http://websocket;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_next_upstream non_idempotent invalid_header error timeout http_500 http_502 http_504 http_403 http_404;
+        proxy_connect_timeout 7d;
+        proxy_send_timeout 7d;
+        proxy_read_timeout 7d;
+    }
+}

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,39 +1,36 @@
-events {}
-http {
-    upstream geth {
-        server 172.27.0.201:8545;
-        server 172.27.0.202:8545;
+upstream geth {
+    server 172.27.0.201:8545;
+    server 172.27.0.202:8545;
+}
+
+upstream websocket {
+    server 172.27.0.201:8546;
+    server 172.27.0.202:8546;
+}
+
+server {
+    listen 80;
+
+    location / {
+        proxy_pass http://geth;
+        proxy_next_upstream non_idempotent invalid_header error timeout http_500 http_502 http_504 http_403 http_404;
+        proxy_next_upstream_tries 4;
+        fastcgi_read_timeout 10;
+        proxy_read_timeout 10;
     }
+}
 
-    upstream websocket {
-        server 172.27.0.201:8546;
-        server 172.27.0.202:8546;
-    }
+server {
+    listen 81;
 
-    server {
-        listen 80;
-
-        location / {
-            proxy_pass http://geth;
-            proxy_next_upstream non_idempotent invalid_header error timeout http_500 http_502 http_504 http_403 http_404;
-            proxy_next_upstream_tries 4;
-            fastcgi_read_timeout 10;
-            proxy_read_timeout 10;
-        }
-    }
-
-    server {
-        listen 81;
-
-        location / {
-            proxy_pass http://websocket;
-            proxy_http_version 1.1;
-            proxy_set_header Upgrade $http_upgrade;
-            proxy_set_header Connection "upgrade";
-            proxy_next_upstream non_idempotent invalid_header error timeout http_500 http_502 http_504 http_403 http_404;
-            proxy_connect_timeout 7d;
-            proxy_send_timeout 7d;
-            proxy_read_timeout 7d;
-        }
+    location / {
+        proxy_pass http://websocket;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_next_upstream non_idempotent invalid_header error timeout http_500 http_502 http_504 http_403 http_404;
+        proxy_connect_timeout 7d;
+        proxy_send_timeout 7d;
+        proxy_read_timeout 7d;
     }
 }

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,36 +1,39 @@
-upstream geth {
-    server 172.27.0.201:8545;
-    server 172.27.0.202:8545;
-}
-
-upstream websocket {
-    server 172.27.0.201:8546;
-    server 172.27.0.202:8546;
-}
-
-server {
-    listen 80;
-
-    location / {
-        proxy_pass http://geth;
-        proxy_next_upstream non_idempotent invalid_header error timeout http_500 http_502 http_504 http_403 http_404;
-        proxy_next_upstream_tries 4;
-        fastcgi_read_timeout 10;
-        proxy_read_timeout 10;
+events {}
+http {
+    upstream geth {
+        server 172.27.0.201:8545;
+        server 172.27.0.202:8545;
     }
-}
 
-server {
-    listen 81;
+    upstream websocket {
+        server 172.27.0.201:8546;
+        server 172.27.0.202:8546;
+    }
 
-    location / {
-        proxy_pass http://websocket;
-        proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "upgrade";
-        proxy_next_upstream non_idempotent invalid_header error timeout http_500 http_502 http_504 http_403 http_404;
-        proxy_connect_timeout 7d;
-        proxy_send_timeout 7d;
-        proxy_read_timeout 7d;
+    server {
+        listen 80;
+
+        location / {
+            proxy_pass http://geth;
+            proxy_next_upstream non_idempotent invalid_header error timeout http_500 http_502 http_504 http_403 http_404;
+            proxy_next_upstream_tries 4;
+            fastcgi_read_timeout 10;
+            proxy_read_timeout 10;
+        }
+    }
+
+    server {
+        listen 81;
+
+        location / {
+            proxy_pass http://websocket;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+            proxy_next_upstream non_idempotent invalid_header error timeout http_500 http_502 http_504 http_403 http_404;
+            proxy_connect_timeout 7d;
+            proxy_send_timeout 7d;
+            proxy_read_timeout 7d;
+        }
     }
 }


### PR DESCRIPTION
We use a separate nginx container for geth in several projects, this pr unifies nginx config and allows to override default config